### PR TITLE
Proof of concept with GCHandle

### DIFF
--- a/Arena.cs
+++ b/Arena.cs
@@ -2,19 +2,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Arenas {
     unsafe public class Arena : IDisposable, IEnumerable<ArenaEntry> {
         public const int PageSize = 4096;
 
-        private Dictionary<object, IntPtr> objToPtr;
-        private Dictionary<IntPtr, object> ptrToObj;
+        private Dictionary<object, ObjectEntry> objToPtr;
         private bool disposedValue;
         private List<IntPtr> pages;
         private Dictionary<FreelistKey, IntPtr> freelists;
@@ -22,8 +17,7 @@ namespace Arenas {
         private int enumVersion;
 
         public Arena() {
-            objToPtr = new Dictionary<object, IntPtr>(ObjectReferenceEqualityComparer.Instance);
-            ptrToObj = new Dictionary<IntPtr, object>();
+            objToPtr = new Dictionary<object, ObjectEntry>(ObjectReferenceEqualityComparer.Instance);
             pages = new List<IntPtr>();
             freelists = new Dictionary<FreelistKey, IntPtr>();
 
@@ -234,63 +228,75 @@ namespace Arenas {
             _FreeValues(uref);
         }
 
-        public IntPtr SetOutsidePtr<T>(T value, IntPtr currentValue) where T : class {
-            if (!(value is object) && currentValue == IntPtr.Zero) {
+        internal IntPtr SetOutsidePtr<T>(T value, IntPtr currentHandlePtr) where T : class
+        {
+            if (!(value is object) && currentHandlePtr == IntPtr.Zero) {
                 // both null, do nothing
                 return IntPtr.Zero;
             }
 
-            IntPtr managedPtrBase = IntPtr.Zero;
+            ObjectEntry managedEntry = default;
 
             if (value is object) {
                 // value is not null. get object handle, or create one if none exist
-                if (!objToPtr.TryGetValue(value, out managedPtrBase)) {
+                if (!objToPtr.TryGetValue(value, out managedEntry)) {
                     // heap allocate object handle and clear to zero
-                    managedPtrBase = Marshal.AllocHGlobal(sizeof(ObjectHandle));
-                    *(ObjectHandle*)managedPtrBase = new ObjectHandle();
+                    managedEntry.Handle = GCHandle.Alloc(value, GCHandleType.Weak);
 
                     // add handle to lookup tables
-                    objToPtr[value] = managedPtrBase;
-                    ptrToObj[managedPtrBase] = value;
+                    objToPtr[value] = managedEntry;
                 }
             }
 
-            if (managedPtrBase == currentValue) {
-                // same value, do nothing
-                return managedPtrBase;
+            if (managedEntry.Handle.IsAllocated)
+            {
+                var managedHandlePtr = GCHandle.ToIntPtr(managedEntry.Handle);
+                if (managedHandlePtr == currentHandlePtr)
+                {
+                    // same value, do nothing
+                    return managedHandlePtr;
+                }
             }
 
-            var managedPtr = (ObjectHandle*)managedPtrBase;
-            var currentValuePtr = (ObjectHandle*)currentValue;
+            if (currentHandlePtr != IntPtr.Zero) {
+                var currentHandle = GCHandle.FromIntPtr(currentHandlePtr);
+                var currentTarget = currentHandle.Target;
+                Debug.Assert(currentTarget != null);
 
-            if (currentValuePtr != null) {
+                ObjectEntry currentManagedEntry;
+
+                if (!objToPtr.TryGetValue(currentTarget, out currentManagedEntry))
+                {
+                    throw new InvalidOperationException("Object handle is allocated but not in lookup tables");
+                }
+
                 // current value of field being set isn't null so decrease refcount and clean up if needed
-                currentValuePtr->RefCount--;
+                currentManagedEntry.RefCount--;
 
                 // can clean up here because we've already established the value isn't the same on both sides
-                if (currentValuePtr->RefCount <= 0) {
+                if (currentManagedEntry.RefCount <= 0) {
+
                     // free object handle and remove from lookup tables so .NET's tracing GC can (theoretically)
                     // collect the object being referenced now that no references to it from within this arena exist
-                    Marshal.FreeHGlobal(currentValue);
-                    objToPtr.Remove(ptrToObj[currentValue]);
-                    ptrToObj.Remove(currentValue);
+                    currentHandle.Free();
+                    objToPtr.Remove(currentTarget);
+                }
+                else
+                {
+                    objToPtr[currentTarget] = currentManagedEntry; // update entry in lookup tables
                 }
             }
 
-            if (managedPtr != null) {
+            if (managedEntry.Handle.IsAllocated) {
                 // increase object handle reference count
-                managedPtr->RefCount++;
+                managedEntry.RefCount++;
+                objToPtr[value] = managedEntry; // update entry in lookup tables
+
+                // return new object handle
+                return GCHandle.ToIntPtr(managedEntry.Handle);
             }
 
-            // return new object handle
-            return managedPtrBase;
-        }
-
-        public T GetOutsidePtr<T>(IntPtr value) where T : class {
-            if (value == IntPtr.Zero) {
-                return null;
-            }
-            return (T)ptrToObj[value];
+            return IntPtr.Zero;
         }
 
         public bool VersionsMatch(RefVersion version, IntPtr item) {
@@ -326,15 +332,19 @@ namespace Arenas {
                 Marshal.FreeHGlobal(ptr);
             }
 
-            // free object handles
-            foreach (var ptr in ptrToObj.Keys) {
-                Marshal.FreeHGlobal(ptr);
+            // free GCHandles
+            foreach (var entry in objToPtr.Values)
+            {
+                var gcHandle = entry.Handle;
+                if (gcHandle.IsAllocated)
+                {
+                    gcHandle.Free();
+                }
             }
 
             pages.Clear();
             freelists.Clear();
             objToPtr.Clear();
-            ptrToObj.Clear();
 
             if (ID != Guid.Empty) {
                 arenas.Remove(ID);
@@ -366,7 +376,6 @@ namespace Arenas {
                 pages = null;
                 freelists = null;
                 objToPtr = null;
-                ptrToObj = null;
 
                 disposedValue = true;
             }
@@ -473,11 +482,15 @@ namespace Arenas {
         #endregion
 
         [StructLayout(LayoutKind.Sequential)]
-        private struct ObjectHandle {
+        private struct ObjectEntry
+        {
+            public GCHandle Handle;
+
             public int RefCount;
 
-            public override string ToString() {
-                return $"ObjectHandle(RefCount={RefCount})";
+            public override string ToString()
+            {
+                return $"ObjectEntry(Handle=0x{GCHandle.ToIntPtr(Handle).ToInt64():X16}, RefCount={RefCount})";
             }
         }
 

--- a/Entity.cs
+++ b/Entity.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Arenas {
     [StructLayout(LayoutKind.Sequential)]
@@ -31,7 +27,7 @@ namespace Arenas {
 
         // managed references are routed through the arena using ManagedRef
         public string Name {
-            get { return name.Get<string>(Arena.Get(ArenaID)); }
+            get => name.Get<string>();
             set { name = name.Set(Arena.Get(ArenaID), value); }
         }
 

--- a/ManagedRef.cs
+++ b/ManagedRef.cs
@@ -1,13 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Arenas {
     [StructLayout(LayoutKind.Sequential)]
-    public struct ManagedRef {
+    public readonly struct ManagedRef {
         private readonly IntPtr handle;
 
         public ManagedRef(IntPtr handle) {
@@ -21,11 +17,12 @@ namespace Arenas {
             return new ManagedRef(arena.SetOutsidePtr(value, handle));
         }
 
-        public T Get<T>(Arena arena) where T : class {
-            if (arena == null) {
-                throw new InvalidOperationException("Arena cannot be null in ManagedRef.Get");
+        public T Get<T>() where T : class {
+            if (handle == IntPtr.Zero) {
+                throw new InvalidOperationException("ManagedRef is null");
             }
-            return arena.GetOutsidePtr<T>(handle);
+            GCHandle gcHandle = GCHandle.FromIntPtr(handle);
+            return (T)gcHandle.Target;
         }
 
         public override string ToString() {

--- a/Program.cs
+++ b/Program.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Arenas {
     class Program {


### PR DESCRIPTION
This is just a proof of concept to illustrate the use of GCHandle instead of an internal ObjectHandle, feel free to disregard. 😊 (I haven't checked fully the correctness of the code with this new version)

The benefits are:
* Only 1 Dictionary is required
* No slow allocations with `Marshal.AllocHGlobal`, GCHandle.Alloc being faster (they also could be pooled as a refinement)
* Direct access to managed reference in `ManagedRef.Get<T>()` without the need for the arena
  * So faster access, no dictionary lookup to de-reference the target

(Note: Dunno why this project targets the good old csproj + .NET Framework 4.8.1, but it felt working on a 15 years old .NET codebase! 😅 😀 Is it because you target some kind of Unity that you can't use latest .NET 8+? - side note: things could be even more optimized with .NET 8 for e.g the dictionary access)