### PR TITLE
Arena ID to object mapping no longer stops arenas being collected by GC

### DIFF
--- a/Arena.cs
+++ b/Arena.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -339,7 +340,7 @@ namespace Arenas {
             Clear(false);
         }
 
-        private void Clear(bool disposing) {
+        private void Clear(bool disposing, bool fromFinalizer = false) {
             enumVersion++;
 
             // free GCHandles
@@ -355,15 +356,12 @@ namespace Arenas {
             objToPtr.Clear();
 
             if (disposing) {
-                Remove(id);
+                Remove(id, fromFinalizer);
                 id = ArenaID.Empty;
             }
             else {
-                var oldID = id;
-
-                // removing and re-adding with a new ID will invalidate any stale references
-                Remove(oldID);
-                id = Add(this);
+                // get a new ID to invalidate any stale references
+                ChangeID(this);
 
                 // allocate one page to start
                 AllocPage(PageSize);
@@ -379,7 +377,7 @@ namespace Arenas {
 
                 // free unmanaged resources (unmanaged objects) and override finalizer
                 // set large fields to null
-                Clear(true);
+                Clear(true, !disposing);
 
                 pages = null;
                 freelists = null;
@@ -416,13 +414,17 @@ namespace Arenas {
         #endregion
 
         public bool IsDisposed { get { return disposedValue; } }
+        public ArenaID ID { get { return id; } }
 
         #region Static
+        private const int FinalizedRemovalsPerAdd = 8;
+
         [DllImport("kernel32.dll")]
         private static extern void RtlZeroMemory(IntPtr dst, UIntPtr length);
         private delegate void ZeroMemoryDelegate(IntPtr dst, UIntPtr length);
 
-        private static Dictionary<ArenaID, Arena> arenas;
+        private static ConcurrentQueue<ArenaID> finalizedRemovals;
+        private static Dictionary<ArenaID, WeakReference<Arena>> arenas;
         private static object arenasLock;
         private static Dictionary<Type, TypeHandle> typeToHandle;
         private static Dictionary<TypeHandle, Type> handleToType;
@@ -437,7 +439,8 @@ namespace Arenas {
                 ZeroMemory = ZeroMemPlatformIndependent;
             }
 
-            arenas = new Dictionary<ArenaID, Arena>();
+            finalizedRemovals = new ConcurrentQueue<ArenaID>();
+            arenas = new Dictionary<ArenaID, WeakReference<Arena>>();
             arenasLock = new object();
 
             typeToHandle = new Dictionary<Type, TypeHandle>();
@@ -446,22 +449,55 @@ namespace Arenas {
         }
 
         private static ArenaID Add(Arena arena) {
+            bool doRemovals = true;
+
             while (true) {
                 var id = ArenaID.NewID();
                 Debug.Assert(id.Value != 0);
+
                 lock (arenasLock) {
+                    if (doRemovals && !finalizedRemovals.IsEmpty) {
+                        // if there are pending removals via finalizer, remove them now
+                        // but only remove a limited number as to not block for too long
+                        for (int i = 0; i < FinalizedRemovalsPerAdd; i++) {
+                            ArenaID removeID;
+                            if (finalizedRemovals.TryDequeue(out removeID)) {
+                                arenas.Remove(removeID);
+                                doRemovals = false;
+                            }
+                        }
+                    }
+
                     if (arenas.ContainsKey(id)) {
                         continue;
                     }
-                    arenas[id] = arena;
+
+                    arenas[id] = new WeakReference<Arena>(arena);
                 }
+
                 return id;
             }
         }
 
-        private static void Remove(ArenaID id) {
-            lock (arenasLock) {
-                arenas.Remove(id);
+        private static void ChangeID(Arena arena) {
+            var oldID = arena.id;
+            arena.id = Add(arena);
+            if (oldID != ArenaID.Empty) {
+                Remove(oldID, false);
+            }
+        }
+
+        private static void Remove(ArenaID id, bool fromFinalizer) {
+            if (fromFinalizer) {
+                // don't lock in code called from finalizer, instead
+                // add to removals queue which is emptied during Add
+                finalizedRemovals.Enqueue(id);
+            }
+            else {
+                // removal from Dispose (or Clear) method, remove now
+                lock (arenasLock) {
+                    arenas.Remove(id);
+                }
             }
         }
 
@@ -470,11 +506,17 @@ namespace Arenas {
                 return null;
             }
 
+            WeakReference<Arena> aref;
             lock (arenasLock) {
-                Arena arena;
-                if (!arenas.TryGetValue(id, out arena)) {
+                if (!arenas.TryGetValue(id, out aref)) {
                     return null;
                 }
+
+                Arena arena;
+                if (!aref.TryGetTarget(out arena)) {
+                    return null;
+                }
+
                 return arena;
             }
         }


### PR DESCRIPTION
Arena kept a static Dictionary<ArenaID, Arena> which was keeping Arena objects alive indefinitely unless removed via calling Dispose(). This PR fixes that issue by using WeakReferences. Additionally, the Arena finalizer now routes through a ConcurrentQueue which is emptied when arena objects are added to the mapping via Add, so as to avoid blocking code inside the finalizer.